### PR TITLE
[WIP] Vectorized `check_parallel_jacobian` implementation that checks sparsity pattern 

### DIFF
--- a/idaes/core/util/model_diagnostics.py
+++ b/idaes/core/util/model_diagnostics.py
@@ -3713,6 +3713,7 @@ def ipopt_solve_halt_on_error(model, options=None):
     )
 
 
+from pyomo.common.timing import HierarchicalTimer
 def check_parallel_jacobian(
     model,
     tolerance: float = 1e-8,
@@ -3721,6 +3722,7 @@ def check_parallel_jacobian(
     jac=None,
     nlp=None,
     method="vectorized-with-filter",
+    timer=None,
 ):
     if method == "vectorized":
         return _check_parallel_jacobian_vectorized(
@@ -3730,6 +3732,7 @@ def check_parallel_jacobian(
             zero_norm_tolerance=zero_norm_tolerance,
             jac=jac,
             nlp=nlp,
+            timer=timer,
         )
     elif method == "vectorized-with-filter":
         return _check_parallel_jacobian_vectorized_with_filter(
@@ -3738,6 +3741,7 @@ def check_parallel_jacobian(
             direction=direction,
             jac=jac,
             nlp=nlp,
+            timer=timer,
         )
 
 
@@ -3747,7 +3751,10 @@ def _check_parallel_jacobian_vectorized_with_filter(
     direction: str = "row",
     jac=None,
     nlp=None,
+    timer=None,
 ):
+    if timer is None:
+        timer = HierarchicalTimer()
     if direction not in ["row", "column"]:
         raise ValueError(
             f"Unrecognised value for direction ({direction}). "
@@ -3756,6 +3763,7 @@ def _check_parallel_jacobian_vectorized_with_filter(
 
     if jac is None or nlp is None:
         jac, nlp = get_jacobian(model, scaled=False)
+    timer.start("construct-initial-matrices")
     jac.sum_duplicates()
 
     # Get vectors that we will check, and the Pyomo components
@@ -3768,15 +3776,25 @@ def _check_parallel_jacobian_vectorized_with_filter(
         components = nlp.get_pyomo_variables()
         mat = jac.transpose().tocsr()
     ncomp = len(components)
+    timer.stop("construct-initial-matrices")
+
+    timer.start("dot-products")
     dotprods = mat @ mat.transpose()
     dotprods.sum_duplicates()
+    timer.stop("dot-products")
 
+    timer.start("norms")
     norms = np.sqrt(dotprods.diagonal())
+    timer.stop("norms")
+
     # Only consider the upper triangle, so we don't do extra work
+    timer.start("upper-tri")
     dotprods = sps.triu(dotprods, k=1)
     dotprods.sum_duplicates()
+    timer.stop("upper-tri")
 
     # Filter small nonzero entries from original matrix
+    timer.start("filter-small-entries")
     max_val_per_component = np.array(
         [max(np.abs(mat.data[mat.indptr[i]:mat.indptr[i+1]]), default=0.0) for i in range(ncomp)]
     )
@@ -3798,7 +3816,9 @@ def _check_parallel_jacobian_vectorized_with_filter(
         shape=coo.shape,
     ).tocsr()
     mat = filtered_mat
+    timer.stop("filter-small-entries")
 
+    timer.start("compare-nonzero-pattern")
     nnz_by_component = np.array([mat.indptr[i+1] - mat.indptr[i] for i in range(ncomp)])
     max_nnz = max(nnz_by_component)
     
@@ -3831,16 +3851,23 @@ def _check_parallel_jacobian_vectorized_with_filter(
     # These are the dot product indices where the two vectors have the same
     # sparsity structure.
     indices_to_extract = np.where((row_nz_mat == col_nz_mat).all(axis=1))[0]
+    timer.stop("compare-nonzero-pattern")
 
+    timer.start("extract-indices")
     filtered_rows = dotprods.row[indices_to_extract]
     filtered_cols = dotprods.col[indices_to_extract]
     filtered_prods = dotprods.data[indices_to_extract]
     norm_prod = norms[filtered_rows] * norms[filtered_cols]
+    timer.stop("extract-indices")
+    timer.start("differences")
     differences = norm_prod - np.abs(filtered_prods)
+    timer.stop("differences")
 
+    timer.start("compare-to-tolerance")
     parallel = np.where(
         (differences < tolerance) | (differences < (norm_prod * tolerance))
     )[0]
+    timer.stop("compare-to-tolerance")
 
     parallel_components = [
         (components[filtered_rows[idx]], components[filtered_cols[idx]])
@@ -3857,6 +3884,7 @@ def _check_parallel_jacobian_vectorized(
     zero_norm_tolerance: float = 1e-8,
     jac=None,
     nlp=None,
+    timer=None,
 ):
     """
     Check for near-parallel rows or columns in the Jacobian.
@@ -3888,6 +3916,8 @@ def _check_parallel_jacobian_vectorized(
 
     """
     # Thanks to Robby Parker and Doug Allan for significant performance improvements
+    if timer is None:
+        timer = HierarchicalTimer()
 
     if direction not in ["row", "column"]:
         raise ValueError(
@@ -3900,6 +3930,7 @@ def _check_parallel_jacobian_vectorized(
 
     # Get vectors that we will check, and the Pyomo components
     # they correspond to.
+    timer.start("initial-matrices")
     if direction == "row":
         components = nlp.get_pyomo_constraints()
         mat = jac.tocsr()
@@ -3907,32 +3938,42 @@ def _check_parallel_jacobian_vectorized(
     elif direction == "column":
         components = nlp.get_pyomo_variables()
         mat = jac.transpose().tocsr()
+    timer.stop("initial-matrices")
 
     # Take product of all rows/columns with all rows/columns by taking outer
     # product of matrix with itself
+    timer.start("dot-products")
     outer = mat @ mat.transpose()
+    timer.stop("dot-products")
 
     # Along the diagonal of the outer product you get the dot product of the row
     # with itself, which is equal to the norm squared.
+    timer.start("norms")
     norms = np.sqrt(outer.diagonal())
+    timer.stop("norms")
 
     # Want to ignore indices with zero norm. By zeroing out the corresponding
     # entries of the scaling matrix, we set the corresponding rows and columns
     # to zero, which will then be ignored.
 
+    timer.start("inv-norms")
     zero_norm_indices = np.nonzero(np.abs(norms) <= zero_norm_tolerance)
     inv_norms = 1 / norms
     inv_norms[zero_norm_indices] = 0
+    timer.stop("inv-norms")
 
     # Divide each row and each column by the vector norm. This leaves
     # the entries as dot(u, v) / (norm(u) * norm(v)). The exception is
     # entries with "zero norm", whose corresponding rows and columns are
     # set to zero.
+    timer.start("scale-by-norms")
     scaling = diags(inv_norms)
     outer = scaling * outer * scaling
+    timer.stop("scale-by-norms")
 
     # Get rid of duplicate values by only taking (strictly) upper triangular part of
     # resulting matrix
+    timer.start("upper-tri")
     upper_tri = triu(outer, k=1)
 
     # Set diagonal elements to zero
@@ -3944,6 +3985,7 @@ def _check_parallel_jacobian_vectorized(
     # Get the nonzero entries of upper_tri in three arrays,
     # corresponding to row indices, column indices, and values
     rows, columns, values = find(upper_tri)
+    timer.stop("upper-tri")
 
     # We have that dot(u,v) == norm(u) * norm(v) * cos(theta) in which
     # theta is the angle between u and v. If theta is approximately
@@ -3954,7 +3996,9 @@ def _check_parallel_jacobian_vectorized(
     # The expression (1 - abs(values) < tolerance) returns an array with values
     # of ones and zeros, depending on whether the condition is fulfilled or not.
     # We then find indices where it is filled using np.nonzero.
+    timer.start("compare-to-tolerance")
     parallel_1D = np.nonzero(1 - abs(values) < tolerance)[0]
+    timer.stop("compare-to-tolerance")
 
     parallel = [
         (components[rows[idx]], components[columns[idx]]) for idx in parallel_1D

--- a/idaes/core/util/tests/test_model_diagnostics.py
+++ b/idaes/core/util/tests/test_model_diagnostics.py
@@ -1123,7 +1123,7 @@ The following pairs of constraints are nearly parallel:
 
         warnings, next_steps = dt._collect_numerical_warnings()
 
-        assert len(warnings) == 4
+        assert len(warnings) == 3
         assert (
             "WARNING: 2 Variables with extreme Jacobian values (<1.0E-08 or >1.0E+08)"
             in warnings
@@ -1134,7 +1134,7 @@ The following pairs of constraints are nearly parallel:
         )
         assert "WARNING: 1 Constraint with large residuals (>1.0E-05)" in warnings
 
-        assert len(next_steps) == 5
+        assert len(next_steps) == 4
         assert "display_variables_with_extreme_jacobians()" in next_steps
         assert "display_constraints_with_extreme_jacobians()" in next_steps
         assert "display_constraints_with_large_residuals()" in next_steps


### PR DESCRIPTION
Inspired by your matmul-based implementation, I tried to re-create my original algorithm doing all computations in NumPy/SciPy. The main difference is that the original algorithm only compares vector-pairs that have the same (approximate) nonzero pattern. This branch contains calls to `HierarchicalTimer` to record timing information for profiling purposes.

Here is a script to profile on a Pyomo.DAE distillation column model:
```python
from pyomo.environ import *
from pyomo.dae import *
from distill_DAE import model

instance = model.create_instance('distill.dat')

# Discretize using Finite Difference Approach
discretizer = TransformationFactory('dae.finite_difference')
discretizer.apply_to(instance, nfe=1000, scheme='BACKWARD')

from idaes.core.util.model_diagnostics import check_parallel_jacobian
from pyomo.common.timing import TicTocTimer, HierarchicalTimer
from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP

instance.obj = Objective(expr=0)
nlp = PyomoNLP(instance)
jac = nlp.evaluate_jacobian()

print(f"Jacobian shape: {jac.shape}")

timer = TicTocTimer()
htimer = HierarchicalTimer()

timer.tic()
htimer.start("root")
htimer.start("vectorized")
check_parallel_jacobian(None, nlp=nlp, jac=jac, method="vectorized", timer=htimer)
htimer.stop("vectorized")
timer.toc("vectorized")
htimer.start("new")
check_parallel_jacobian(None, nlp=nlp, jac=jac, method="vectorized-with-filter", timer=htimer)
htimer.stop("new")
timer.toc("new")
htimer.stop("root")

print(htimer)
```
My results:
```console
Jacobian shape: (100068, 101069)
[    0.00] Resetting the tic/toc delta timer
[+   0.10] vectorized
[+   0.73] new
Identifier                                  ncalls   cumtime   percall      %
-----------------------------------------------------------------------------
root                                             1     0.829     0.829  100.0
     ------------------------------------------------------------------------
     new                                         1     0.733     0.733   88.4
               --------------------------------------------------------------
               compare-nonzero-pattern           1     0.273     0.273   37.3
               compare-to-tolerance              1     0.000     0.000    0.0
               construct-initial-matrices        1     0.045     0.045    6.1
               differences                       1     0.000     0.000    0.0
               dot-products                      1     0.023     0.023    3.1
               extract-indices                   1     0.000     0.000    0.0
               filter-small-entries              1     0.364     0.364   49.6
               norms                             1     0.001     0.001    0.1
               upper-tri                         1     0.026     0.026    3.6
               other                           n/a     0.001       n/a    0.2
               ==============================================================
     vectorized                                  1     0.096     0.096   11.6
               --------------------------------------------------------------
               compare-to-tolerance              1     0.001     0.001    1.1
               dot-products                      1     0.013     0.013   13.2
               initial-matrices                  1     0.031     0.031   32.6
               inv-norms                         1     0.000     0.000    0.1
               norms                             1     0.001     0.001    1.1
               scale-by-norms                    1     0.018     0.018   18.4
               upper-tri                         1     0.031     0.031   31.9
               other                           n/a     0.001       n/a    1.5
               ==============================================================
     other                                     n/a     0.000       n/a    0.0
     ========================================================================
=============================================================================
```
And here is a script to profile on my singular-MBR example:
```python
from idaes_examples.mod.diagnostics.gas_solid_contactors.example import (
    create_square_model_with_new_variable_and_constraint,
    create_corrected_square_model,
)
from idaes.core.util.model_diagnostics import (
    DiagnosticsToolbox,
    check_parallel_jacobian,
)

m = create_square_model_with_new_variable_and_constraint()
#m = create_corrected_square_model()
#dt = DiagnosticsToolbox(m)

#dt.report_structural_issues()
#dt.report_numerical_issues()
#dt.display_near_parallel_constraints()

from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
from pyomo.common.timing import TicTocTimer, HierarchicalTimer
nlp = PyomoNLP(m)
jac = nlp.evaluate_jacobian()

htimer = HierarchicalTimer()
timer = TicTocTimer()
timer.tic()

htimer.start("root")
htimer.start("vectorized")
parallel = check_parallel_jacobian(None, nlp=nlp, jac=jac, method="vectorized", timer=htimer)
print(f"N. parallel = {len(parallel)}")
htimer.stop("vectorized")
timer.toc("vectorized")
htimer.start("new")
parallel = check_parallel_jacobian(None, nlp=nlp, jac=jac, method="vectorized-with-filter", timer=htimer)
print(f"N. parallel = {len(parallel)}")
htimer.stop("new")
timer.toc("new")
htimer.stop("root")

print(htimer)
```
My results:
```console
[    0.00] Resetting the tic/toc delta timer
N. parallel = 1012
[+   0.04] vectorized
N. parallel = 11
[+   0.12] new
Identifier                                  ncalls   cumtime   percall      %
-----------------------------------------------------------------------------
root                                             1     0.159     0.159  100.0
     ------------------------------------------------------------------------
     new                                         1     0.123     0.123   77.6
               --------------------------------------------------------------
               compare-nonzero-pattern           1     0.050     0.050   40.1
               compare-to-tolerance              1     0.000     0.000    0.0
               construct-initial-matrices        1     0.005     0.005    3.7
               differences                       1     0.000     0.000    0.0
               dot-products                      1     0.018     0.018   14.2
               extract-indices                   1     0.000     0.000    0.0
               filter-small-entries              1     0.038     0.038   30.5
               norms                             1     0.000     0.000    0.2
               upper-tri                         1     0.014     0.014   11.0
               other                           n/a     0.000       n/a    0.3
               ==============================================================
     vectorized                                  1     0.036     0.036   22.4
               --------------------------------------------------------------
               compare-to-tolerance              1     0.000     0.000    1.4
               dot-products                      1     0.004     0.004   11.6
               initial-matrices                  1     0.003     0.003    9.2
               inv-norms                         1     0.000     0.000    0.1
               norms                             1     0.000     0.000    0.9
               scale-by-norms                    1     0.009     0.009   24.3
               upper-tri                         1     0.018     0.018   49.3
               other                           n/a     0.001       n/a    3.2
               ==============================================================
     other                                     n/a     0.000       n/a    0.0
     ========================================================================
=============================================================================
```
This implementation is still a factor of 3-10 slower than your vectorized implementation, but it does significantly reduce the bottleneck due to sorting and comparing nonzero structures compared to the original, pure-Python implementation. I have not spent much time optimizing `compare-nonzero-pattern` and `filter-small-entries`, so further improvements may be possible. 

What do you think about this algorithm, if it is possible to reduce the run time a bit more?